### PR TITLE
Fix typo in `norank` attribute.

### DIFF
--- a/docs/layout/layout.rst
+++ b/docs/layout/layout.rst
@@ -34,7 +34,7 @@ We can specify a connection direction as follows and this affects the diagram la
     ``-down->``  or ``-d->``, "vertical top to bottom" 
     ``-left->`` or ``-l->``, "horizontal right to left"
     ``-right->`` or ``-r->``, "horizontal left to right"
-    ``--norank]>``, "make a connection less important"
+    ``--[norank]>``, "make a connection less important"
     ``--[hidden]>``, "hidden"
     ``-[hidden]d->``, "hidden with direction e.g. down"
     ``--->`` or ``---->`` or ``----->`` ... , "varying arrow lengths; add dashes to make line longer"


### PR DESCRIPTION
The opening bracket `[` was missing.